### PR TITLE
修复MenuService的bug&修复历史订单的bug

### DIFF
--- a/ruoyi-admin/src/main/resources/templates/clienthomeorder/homeorder/homeorder.html
+++ b/ruoyi-admin/src/main/resources/templates/clienthomeorder/homeorder/homeorder.html
@@ -128,7 +128,7 @@
         var editFlag = [[${@permission.hasPermi('clienthomeorder:homeorder:edit')}]];
         var removeFlag = [[${@permission.hasPermi('clienthomeorder:homeorder:remove')}]];
         var commentsFlag = [[${@permission.hasPermi('clienthomeorder:homeorder:comment')}]];
-        var querycommentsFlag = [[${@permission.hasPermi('landlordhomeorder:landlordorder:querycomment')}]];
+        var querycommentsFlag = [[${@permission.hasPermi('clienthomeorder:homeorder:querycomment')}]];
         var isPaidDatas = [[${@dict.getType('sys_user_is_paid')}]];
         var isDoneDatas = [[${@dict.getType('sys_user_is_done')}]];
         var prefix = ctx + "clienthomeorder/homeorder";

--- a/ruoyi-admin/src/main/resources/templates/clientspecialtyorder/clientorder/clientorder.html
+++ b/ruoyi-admin/src/main/resources/templates/clientspecialtyorder/clientorder/clientorder.html
@@ -125,7 +125,7 @@
 <script th:inline="javascript">
     var editFlag = [[${@permission.hasPermi('clientspecialtyorder:clientorder:edit')}]];
     var removeFlag = [[${@permission.hasPermi('clientspecialtyorder:clientorder:remove')}]];
-    var querycommentsFlag = [[${@permission.hasPermi('landlordhomeorder:landlordorder:querycomment')}]];
+    var querycommentsFlag = [[${@permission.hasPermi('clientspecialtyorder:clientorder:querycomment')}]];
     var commentsFlag = [[${@permission.hasPermi('clientspecialtyorder:clientorder:comment')}]];
     var isReceivedDatas = [[${@dict.getType('sys_user_is_received')}]];
     var isPaidDatas = [[${@dict.getType('sys_user_is_paid')}]];

--- a/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysMenuServiceImpl.java
+++ b/ruoyi-system/src/main/java/com/ruoyi/system/service/impl/SysMenuServiceImpl.java
@@ -50,7 +50,7 @@ public class SysMenuServiceImpl implements ISysMenuService
         }
 
         for (SysRole role : roles) {
-            if (role.getRoleId() == 1) {
+            if (role.isFlag() && role.getRoleId() == 1) {
                 return true;
             }
         }


### PR DESCRIPTION
1. 修复MenuService里isAdmin的bug，现在菜单不同角色选择性展示没有问题了，但12.23在尝试中出现对应角色菜单已经选择性展示以及本人在权限管理部分开发时也测试过的选择性展示的玄学问题仍没有找到原因；
2. 修复历史订单（民宿+特产）因前端按钮要求的权限字符、后端Controller要求的权限字符与对应菜单设置的权限字符不一致的bug。